### PR TITLE
Patch 1

### DIFF
--- a/gcp/gke/README.md
+++ b/gcp/gke/README.md
@@ -26,7 +26,7 @@ gcloud init
 
 ### Creating Google Cloud project and service account for terraform
 
-Best practice to use separate account "technical account" to manage infrastructure, this account can be used in automated code deployment like in Terraform or XL Deploy or any other product you may choose.
+Best practice to use separate account "technical account" to manage infrastructure, this account can be used to interact with GCP by Terraform, XL Deploy or any other product you may choose.
 
 > NOTE: You need to have proper permissions and privileges in the GCP account to execute these commands. If you are using a personal account you should be having these as you will be the admin. If you are using a company/enterprise account please check with your account administrator. 
 

--- a/gcp/gke/README.md
+++ b/gcp/gke/README.md
@@ -26,7 +26,7 @@ gcloud init
 
 ### Creating Google Cloud project and service account for terraform
 
-Best practice to use separate account "technical account" to manage infrastructure, this account can be used in automated code deployment like in Terraform or XL-Deploy or any other tool you may choose.
+Best practice to use separate account "technical account" to manage infrastructure, this account can be used in automated code deployment like in Terraform or XL Deploy or any other product you may choose.
 
 > NOTE: You need to have proper permissions and privileges in the GCP account to execute these commands. If you are using a personal account you should be having these as you will be the admin. If you are using a company/enterprise account please check with your account administrator. 
 
@@ -42,7 +42,7 @@ export TF_ADMIN=[GCP project ID]
 
 Create a new project and link it to your billing account (You could do it from the GCP console GUI as well, in that case skip the below command)
 
-> NOTE: The value of YOUR_ORG_ID and YOUR_BILLING_ACCOUNT_ID can be found by running below commands
+> NOTE: The value of `YOUR_ORG_ID` and `YOUR_BILLING_ACCOUNT_ID` can be found by running below commands
 
 ```sh
 gcloud organizations list
@@ -63,7 +63,7 @@ gcloud beta billing projects link ${TF_ADMIN} \
 
 #### Create the Terraform service account
 
-Create the service account in the GCP project and download the JSON credentials(This will be needed later for the blueprints):
+Create the service account in the GCP project and download the JSON credentials (this will be needed later for the blueprints):
 
 ```sh
 gcloud iam service-accounts create terraform \

--- a/gcp/gke/xebialabs/USAGE.md.tmpl
+++ b/gcp/gke/xebialabs/USAGE.md.tmpl
@@ -19,13 +19,13 @@ To deploy this blueprint, follow the steps below:
     xl apply -f xebialabs.yaml
     ```
 
-2. Go to XL Release, look for the "{{$cluster}}-create" template, and start a new release from it.
-3. Once you are done, go to XL Release, look for the "{{$cluster}}-destroy" template, and start a new release from it to automatically rollback and destroy the resources you created.
+2. Go to XL Release, click on `Design`, then `Templates` and look for the "{{$cluster}}-create" template, and start a new release from it.
+3. Once you are done, go to XL Release, look for the "{{$cluster}}-destroy" template in the same location, and start a new release from it to automatically rollback and destroy the resources you created.
 
 ## Minimum Required versions
 
-This blueprint version requires at least the below versions of the specified tools to work properly.
+This blueprint version requires at least the below versions of the specified products to work properly.
 
-XL Release: Version 8.6.1
-XL Deploy: Version 8.6.1
-XL CLI: Version 8.6
+- XL Release: Version 8.6.1
+- XL Deploy: Version 8.6.1
+- XL CLI: Version 8.6

--- a/gcp/gke/xebialabs/USAGE.md.tmpl
+++ b/gcp/gke/xebialabs/USAGE.md.tmpl
@@ -19,8 +19,8 @@ To deploy this blueprint, follow the steps below:
     xl apply -f xebialabs.yaml
     ```
 
-2. Go to XL Release, click on `Design`, then `Templates` and look for the "{{$cluster}}-create" template, and start a new release from it.
-3. Once you are done, go to XL Release, look for the "{{$cluster}}-destroy" template in the same location, and start a new release from it to automatically rollback and destroy the resources you created.
+2. Go to XL Release, click on `Design`, then navigate to  the `{{$cluster}}` folder and look for the "{{$cluster}}-create" under `Templates`, and start a new release from it.
+3. Once you are done, go to XL Release, look for the "{{$cluster}}-destroy" template in the same location, and start it to automatically rollback and destroy the resources you created.
 
 ## Minimum Required versions
 


### PR DESCRIPTION
## Definition of Done

This is the definition of done for (new and modified) blueprints to be accepted into the [central XebiaLabs blueprints repository](https://github.com/xebialabs/blueprints).

### Value

This section describes how to determine whether a blueprint has enough value to be included in the central XebiaLabs blueprints repository.

- [ ] The blueprint applies to a focused use case.
- [ ] The blueprint uses at least one XebiaLabs product.
- [ ] The blueprint depends on as few other products as possible. **N.B.:** This is part of the definition of done to keep the blueprint focused and applicable to as many users as possible. A blueprint that depends on one specific CI tool **and** one specific Java EE application server **and** one specific ticketing system can only be used by users that have all three products.
- [ ] The blueprint can be used with content supplied by the user but also includes demo content. A blueprint that does not work with content supplied by the user is a demo or a showcase and does not help the user with their own work.

### Technical

This section describes how to determine whether the blueprint has the right technical quality to be included in the central XebiaLabs blueprints repository.

- [ ] The branch from which the PR is created is up-to-date with the `development` branch.
- [ ] The blueprint contains a `README.md` file at the root of the blueprint folder that describes the blueprint, using the README template in the `.github` folder of this repository.
- [ ] The blueprint generates a `xebialabs/USAGE.md` file which, at a minimum, explains how to use the blueprint after it is generated (like adding any missing steps, creating accounts, setting up Docker containers, applying the YAML using `xl` CLI, running release. etc.). **N.B.:** Do not use this document to describe how to instantiate the blueprint. It will only be available to the user *after* the blueprint has been instantiated.
- [ ] The blueprint generates a `docker/docker-compose.yml` file which can be used to spin up the required products that the blueprints uses. This can be used to test and/or try out the blueprint without having to manually install those products.
- [ ] The blueprint does not contain sensitive information such passwords, tokens, credentials or licenses.
- [ ] The blueprint uses `secret: true` in the `blueprint.yaml` parameter definition for question that ask for sensitive information.
- [ ] The blueprint does not contain the files `xebialabs/.gitignore`, `xebialabs/values.xlvals` and `xebialabs/secrets.xlvals` and does not refer to them from the files section of the `blueprint.yaml` file. These files will be generated when the blueprint is instantiated. To generate the `xebialabs/values.xlvals` file, use the `saveInXlVals: true` directive in the parameters section of the blueprint. To generate the `xebialabs/secrets.xlvals` file, use the `secret: true` directive .
- [ ] The blueprint does not define parameters for trivial things like phase names, task names, folder names etc. Ask questions that add value and be opinionated where possible. For example, ask for a project name and derive folder names, task names etc from that.
- [ ] Folder and file names must use [kebab-case](http://wiki.c2.com/?KebabCase), for example: `aws/sample-app-demo`, `xld-environment.yaml`

### Review and testing

This section describes how to determine whether the blueprint has been reviewed and tested well enough to be included in the central XebiaLabs blueprints repository.

- [ ] Unit test is added in a `__test__` folder for each blueprint. Refer the `CONTRIBUTING.md` file at the root of of this repository for more details.
- [ ] The Travis CI for the PR is green
- [ ] The blueprint has been reviewed by someone else in the team.
- [ ] Both README and USAGE files have been reviewed by a technical writer and a product marketing manager.
- [ ] The blueprint has been manually tested with the `docker/docker-compose.yml` that is generated as part of it.
- [ ] The blueprint works on Linux, Mac and Windows.
